### PR TITLE
Update to latest litenetlib 1.0.1. Use interface instead of EventBased listener which speedups things alot.

### DIFF
--- a/NetworkBenchmarkDotNet/Libraries/LiteNetLib/EchoClient.cs
+++ b/NetworkBenchmarkDotNet/Libraries/LiteNetLib/EchoClient.cs
@@ -44,6 +44,7 @@ namespace NetworkBenchmark.LiteNetLib
 				netManager.IPv6Mode = IPv6Mode.Disabled;
 			}
 
+			//netManager.UseNativeSockets = true;
 			netManager.UpdateTime = Utilities.CalculateTimeout(config.ClientTickRate);
 			netManager.UnsyncedEvents = true;
 			netManager.DisconnectTimeout = 10000;

--- a/NetworkBenchmarkDotNet/Libraries/LiteNetLib/EchoClient.cs
+++ b/NetworkBenchmarkDotNet/Libraries/LiteNetLib/EchoClient.cs
@@ -16,7 +16,7 @@ using LiteNetLib;
 
 namespace NetworkBenchmark.LiteNetLib
 {
-	internal class EchoClient : AClient, IClient
+	internal class EchoClient : AClient, IClient, INetEventListener
 	{
 		public override bool IsConnected => isConnected;
 		public override bool IsDisposed => isDisposed;
@@ -27,7 +27,6 @@ namespace NetworkBenchmark.LiteNetLib
 		private readonly Configuration config;
 		private readonly BenchmarkStatistics benchmarkStatistics;
 
-		private readonly EventBasedNetListener listener;
 		private readonly NetManager netManager;
 		private readonly DeliveryMethod deliveryMethod;
 		private NetPeer peer;
@@ -39,15 +38,10 @@ namespace NetworkBenchmark.LiteNetLib
 			this.benchmarkStatistics = benchmarkStatistics;
 			deliveryMethod = LiteNetLibBenchmark.GetDeliveryMethod(config.Transmission);
 
-			listener = new EventBasedNetListener();
-			netManager = new NetManager(listener);
+			netManager = new NetManager(this);
 			if (!config.Address.Contains(':'))
 			{
-				// For LiteNetLib 1.0 and above
-				//netManager.IPv6Mode = IPv6Mode.Disabled;
-
-				// LiteNetLib up to 0.9.4
-				netManager.IPv6Enabled = IPv6Mode.Disabled;
+				netManager.IPv6Mode = IPv6Mode.Disabled;
 			}
 
 			netManager.UpdateTime = Utilities.CalculateTimeout(config.ClientTickRate);
@@ -56,11 +50,6 @@ namespace NetworkBenchmark.LiteNetLib
 
 			isConnected = false;
 			isDisposed = false;
-
-			listener.PeerConnectedEvent += OnPeerConnected;
-			listener.PeerDisconnectedEvent += OnPeerDisconnected;
-			listener.NetworkReceiveEvent += OnNetworkReceive;
-			listener.NetworkErrorEvent += OnNetworkError;
 		}
 
 		public override void StartClient()
@@ -101,11 +90,6 @@ namespace NetworkBenchmark.LiteNetLib
 
 		public override void Dispose()
 		{
-			listener.PeerConnectedEvent -= OnPeerConnected;
-			listener.PeerDisconnectedEvent -= OnPeerDisconnected;
-			listener.NetworkReceiveEvent -= OnNetworkReceive;
-			listener.NetworkErrorEvent -= OnNetworkError;
-
 			isDisposed = true;
 		}
 
@@ -136,12 +120,12 @@ namespace NetworkBenchmark.LiteNetLib
 			Interlocked.Increment(ref benchmarkStatistics.MessagesClientSent);
 		}
 
-		private void OnPeerConnected(NetPeer peer)
+		void INetEventListener.OnPeerConnected(NetPeer peer)
 		{
 			isConnected = true;
 		}
 
-		private void OnPeerDisconnected(NetPeer peer, DisconnectInfo disconnectInfo)
+		void INetEventListener.OnPeerDisconnected(NetPeer peer, DisconnectInfo disconnectInfo)
 		{
 			if (disconnectInfo.Reason == DisconnectReason.Timeout && (BenchmarkRunning || BenchmarkPreparing))
 			{
@@ -153,7 +137,7 @@ namespace NetworkBenchmark.LiteNetLib
 			isConnected = false;
 		}
 
-		private void OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliverymethod)
+		void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliverymethod)
 		{
 			if (BenchmarkRunning)
 			{
@@ -168,7 +152,11 @@ namespace NetworkBenchmark.LiteNetLib
 			reader.Recycle();
 		}
 
-		private void OnNetworkError(IPEndPoint endpoint, SocketError socketerror)
+		void INetEventListener.OnNetworkReceiveUnconnected(IPEndPoint remoteEndPoint, NetPacketReader reader, UnconnectedMessageType messageType) { }
+		void INetEventListener.OnNetworkLatencyUpdate(NetPeer peer, int latency) { }
+		void INetEventListener.OnConnectionRequest(ConnectionRequest request) { }
+
+		void INetEventListener.OnNetworkError(IPEndPoint endpoint, SocketError socketerror)
 		{
 			if (BenchmarkRunning)
 			{

--- a/NetworkBenchmarkDotNet/Libraries/LiteNetLib/EchoServer.cs
+++ b/NetworkBenchmarkDotNet/Libraries/LiteNetLib/EchoServer.cs
@@ -16,13 +16,12 @@ using LiteNetLib;
 
 namespace NetworkBenchmark.LiteNetLib
 {
-	internal class EchoServer : AServer
+	internal class EchoServer : AServer, INetEventListener
 	{
 		public override bool IsStarted => netManager != null && netManager.IsRunning;
 
 		private readonly Configuration config;
 		private readonly BenchmarkStatistics benchmarkStatistics;
-		private readonly EventBasedNetListener listener;
 		private readonly NetManager netManager;
 		private readonly DeliveryMethod deliveryMethod;
 
@@ -32,24 +31,14 @@ namespace NetworkBenchmark.LiteNetLib
 			this.benchmarkStatistics = benchmarkStatistics;
 			deliveryMethod = LiteNetLibBenchmark.GetDeliveryMethod(config.Transmission);
 
-			listener = new EventBasedNetListener();
-			netManager = new NetManager(listener);
+			netManager = new NetManager(this);
 			netManager.UpdateTime = Utilities.CalculateTimeout(config.ServerTickRate);
 			if (!config.Address.Contains(':'))
 			{
-				// For LiteNetLib 1.0 and above
-				//netManager.IPv6Mode = IPv6Mode.Disabled;
-
-				// LiteNetLib up to 0.9.4
-				netManager.IPv6Enabled = IPv6Mode.Disabled;
+				netManager.IPv6Mode = IPv6Mode.Disabled;
 			}
 
 			netManager.UnsyncedEvents = true;
-
-			listener.ConnectionRequestEvent += OnConnectionRequest;
-			listener.NetworkReceiveEvent += OnNetworkReceive;
-			listener.NetworkErrorEvent += OnNetworkError;
-			listener.PeerDisconnectedEvent += OnPeerDisconnected;
 		}
 
 		public override void StartServer()
@@ -64,13 +53,7 @@ namespace NetworkBenchmark.LiteNetLib
 			netManager.Stop();
 		}
 
-		public override void Dispose()
-		{
-			listener.ConnectionRequestEvent -= OnConnectionRequest;
-			listener.NetworkReceiveEvent -= OnNetworkReceive;
-			listener.NetworkErrorEvent -= OnNetworkError;
-			listener.PeerDisconnectedEvent -= OnPeerDisconnected;
-		}
+		public override void Dispose() { }
 
 		#region ManualMode
 
@@ -87,7 +70,7 @@ namespace NetworkBenchmark.LiteNetLib
 
 		#endregion
 
-		private void OnConnectionRequest(ConnectionRequest request)
+		void INetEventListener.OnConnectionRequest(ConnectionRequest request)
 		{
 			if (netManager.ConnectedPeerList.Count > config.Clients)
 			{
@@ -98,8 +81,19 @@ namespace NetworkBenchmark.LiteNetLib
 
 			request.Accept();
 		}
+		private void Broadcast(byte[] data, DeliveryMethod delivery)
+		{
+			netManager.SendToAll(data, delivery);
+			var messagesSent = netManager.ConnectedPeersCount;
+			Interlocked.Add(ref benchmarkStatistics.MessagesServerSent, messagesSent);
+		}
 
-		private void OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod clientDeliveryMethod)
+		void INetEventListener.OnNetworkError(IPEndPoint endPoint, SocketError socketError)
+		{
+			Interlocked.Increment(ref benchmarkStatistics.Errors);
+		}
+
+		void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
 		{
 			if (benchmarkRunning)
 			{
@@ -116,19 +110,11 @@ namespace NetworkBenchmark.LiteNetLib
 			reader.Recycle();
 		}
 
-		private void Broadcast(byte[] data, DeliveryMethod delivery)
-		{
-			netManager.SendToAll(data, delivery);
-			var messagesSent = netManager.ConnectedPeersCount;
-			Interlocked.Add(ref benchmarkStatistics.MessagesServerSent, messagesSent);
-		}
+		void INetEventListener.OnNetworkReceiveUnconnected(IPEndPoint remoteEndPoint, NetPacketReader reader, UnconnectedMessageType messageType) { }
+		void INetEventListener.OnNetworkLatencyUpdate(NetPeer peer, int latency) { }
+		void INetEventListener.OnPeerConnected(NetPeer peer) { }
 
-		private void OnNetworkError(IPEndPoint endpoint, SocketError socketerror)
-		{
-			Interlocked.Increment(ref benchmarkStatistics.Errors);
-		}
-
-		private void OnPeerDisconnected(NetPeer peer, DisconnectInfo disconnectinfo)
+		void INetEventListener.OnPeerDisconnected(NetPeer peer, DisconnectInfo disconnectinfo)
 		{
 			if (benchmarkPreparing || benchmarkRunning)
 			{

--- a/NetworkBenchmarkDotNet/Libraries/LiteNetLib/EchoServer.cs
+++ b/NetworkBenchmarkDotNet/Libraries/LiteNetLib/EchoServer.cs
@@ -33,6 +33,7 @@ namespace NetworkBenchmark.LiteNetLib
 
 			netManager = new NetManager(this);
 			netManager.UpdateTime = Utilities.CalculateTimeout(config.ServerTickRate);
+			//netManager.UseNativeSockets = true;
 			if (!config.Address.Contains(':'))
 			{
 				netManager.IPv6Mode = IPv6Mode.Disabled;

--- a/NetworkBenchmarkDotNet/NetworkBenchmarkDotNet.csproj
+++ b/NetworkBenchmarkDotNet/NetworkBenchmarkDotNet.csproj
@@ -32,7 +32,7 @@
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
       <PackageReference Include="ENet-CSharp" Version="2.4.7" />
-      <PackageReference Include="LiteNetLib" Version="1.0.0-rc.3" />
+      <PackageReference Include="LiteNetLib" Version="1.0.1" />
       <PackageReference Include="NetCoreServer" Version="5.1.0" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     </ItemGroup>

--- a/NetworkBenchmarkDotNet/NetworkBenchmarkDotNet.csproj
+++ b/NetworkBenchmarkDotNet/NetworkBenchmarkDotNet.csproj
@@ -32,7 +32,7 @@
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
       <PackageReference Include="ENet-CSharp" Version="2.4.7" />
-      <PackageReference Include="LiteNetLib" Version="0.9.5.2" />
+      <PackageReference Include="LiteNetLib" Version="1.0.0-rc.3" />
       <PackageReference Include="NetCoreServer" Version="5.1.0" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     </ItemGroup>


### PR DESCRIPTION
This PR use latest version of LiteNetLib. Which has many improvements over old version (less copies and more optimizations). Also it changes slow EventBasedListener to fast INetEventListener.

I added this because many users looking at this graphs that doesn't reflect real state of performance.